### PR TITLE
refactor: drop stub backend classes

### DIFF
--- a/src/scaleforge/backend/base.py
+++ b/src/scaleforge/backend/base.py
@@ -17,19 +17,3 @@ class Backend(abc.ABC):
     @abc.abstractmethod
     async def upscale(self, src: Path, dst: Path, scale: int = 2, tile: int | None = None) -> None:  # noqa: D401
         """Upscale one image from src to dst."""
-
-
-class TorchBackend(Backend):
-    name = "torch"
-
-    async def upscale(self, src: Path, dst: Path, scale: int = 2, tile: int | None = None):  # noqa: D401
-        # TODO: implement actual Real-ESRGAN torch inference
-        dst.write_bytes(src.read_bytes())
-
-
-class VulkanBackend(Backend):
-    name = "vulkan"
-
-    async def upscale(self, src: Path, dst: Path, scale: int = 2, tile: int | None = None):  # noqa: D401
-        # TODO: call ncnn vulkan executable via asyncio.subprocess
-        dst.write_bytes(src.read_bytes())


### PR DESCRIPTION
## Summary
- remove placeholder TorchBackend and VulkanBackend from backend base module
- retain only Backend and BackendError; concrete backends live in their own modules

## Testing
- `PYTHONPATH=src pytest`
- `ruff --isolated check src/scaleforge/backend/base.py`


------
https://chatgpt.com/codex/tasks/task_e_68a55caae9f4832ba5105a72f8449a69