### PR TITLE
Run upscaler predict in background thread

### DIFF
--- a/src/scaleforge/backend/torch_backend.py
+++ b/src/scaleforge/backend/torch_backend.py
@@ -166,7 +166,10 @@ class TorchRealESRGANBackend(Backend):
 
         logger.info(f"Upscaling to {scale}x using model '{self.model_name}'")
         img = Image.open(src).convert("RGB")
-        result = self._upsampler.predict(img)
+
+        import asyncio  # Lazy import to keep startup light
+
+        result = await asyncio.to_thread(self._upsampler.predict, img)
 
         dst.parent.mkdir(parents=True, exist_ok=True)
         result.save(dst)

--- a/tests/test_torch_backend.py
+++ b/tests/test_torch_backend.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import asyncio
 import hashlib
 import os
 import sys
@@ -69,7 +68,8 @@ def stub_heavy_deps(tmp_path, monkeypatch):
     )
 
 
-def test_upscale_roundtrip(tmp_path):
+@pytest.mark.asyncio
+async def test_upscale_roundtrip(tmp_path):
     """Backend should save an output file without heavy deps."""
 
     from scaleforge.backend.torch_backend import TorchRealESRGANBackend
@@ -79,7 +79,7 @@ def test_upscale_roundtrip(tmp_path):
     Image.new("RGB", (8, 8), "white").save(src)
 
     backend = TorchRealESRGANBackend(prefer_gpu=False)
-    asyncio.run(backend.upscale(src, dst))
+    await backend.upscale(src, dst)
 
     assert dst.exists()
 


### PR DESCRIPTION
## Summary
- make `TorchRealESRGANBackend.upscale` execute `_upsampler.predict` with `asyncio.to_thread`
- lazily import `asyncio` to keep startup light
- update Torch backend test to await the async call

## Testing
- `PYTHONPATH=src SF_HEAVY_TESTS=1 pytest tests/test_torch_backend.py::test_upscale_roundtrip -vv -k test_upscale_roundtrip`


------
https://chatgpt.com/codex/tasks/task_e_68a55cb09dcc832babf90250f4148e6b