### PR TITLE
Normalize job metadata naming and add propagation test

### DIFF
--- a/src/scaleforge/pipeline/queue.py
+++ b/src/scaleforge/pipeline/queue.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import random
 from pathlib import Path
@@ -70,7 +71,10 @@ class JobQueue:
             try:
                 src = Path(job.src_path)
                 dst = src.with_suffix(src.suffix + ".x2.png")
-                await self.backend.upscale(src, dst)
+                kwargs = {}
+                if "job" in inspect.signature(self.backend.upscale).parameters:
+                    kwargs["job"] = job
+                await self.backend.upscale(src, dst, **kwargs)
                 with get_conn(self.db_path) as conn:
                     job.set_status(conn, JobStatus.DONE)
                 delay = 1.0  # reset back-off on success

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,29 @@
+import asyncio
+from pathlib import Path
+
+from scaleforge.pipeline.queue import JobQueue
+from scaleforge.backend.base import Backend
+
+
+class RecordingBackend(Backend):
+    name = "record"
+
+    def __init__(self):
+        self.received_job = None
+
+    async def upscale(self, src: Path, dst: Path, scale: int = 2, tile: int | None = None, job=None):
+        self.received_job = job
+        dst.write_bytes(src.read_bytes())
+
+
+def test_metadata_propagation(tmp_path):
+    src = tmp_path / "in.png"
+    src.write_bytes(b"123")
+    db = tmp_path / "sf.db"
+    backend = RecordingBackend()
+    queue = JobQueue(db, backend)
+    queue.enqueue([src], model="realesrgan", scale=4)
+    asyncio.run(queue.run())
+
+    assert backend.received_job is not None
+    assert backend.received_job.metadata == {"model": "realesrgan", "scale": 4}


### PR DESCRIPTION
## Summary
- standardize job model to use `metadata` field
- pass job objects through queue workers to backends
- add test ensuring metadata survives enqueue to backend

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55cafb330832bb82c1d8665b30655