### PR TITLE
Implement model downloader and wire CLI install command

### DIFF
--- a/src/scaleforge/cli/main.py
+++ b/src/scaleforge/cli/main.py
@@ -96,7 +96,10 @@ def model_install(model: str) -> None:
         return
 
     click.echo(f"📦 Installing model: {model}")
-    downloader.download_model(model)
+    try:
+        downloader.download_model(model)
+    except Exception as exc:  # pragma: no cover - network/IO errors
+        raise click.ClickException(str(exc)) from exc
     click.echo("✅ Done.")
 
 

--- a/src/scaleforge/models/downloader.py
+++ b/src/scaleforge/models/downloader.py
@@ -1,0 +1,122 @@
+"""Utility for downloading model files from the registry.
+
+This module provides a small :class:`ModelDownloader` class that is used by
+the CLI to fetch model files listed in the ScaleForge registry.  The
+implementation is intentionally lightweight – it only implements the pieces the
+CLI currently relies on: reading the registry, checking if a model has already
+been downloaded and downloading a model while verifying the checksum.
+
+The registry entries are defined in :mod:`scaleforge.models.registry` and are
+validated using :class:`~scaleforge.models.registry.ModelSchema`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import urllib.request
+from pathlib import Path
+from typing import Dict
+
+from scaleforge.config.loader import load_config
+from scaleforge.models.registry import ModelSchema, load_effective_registry
+
+
+@dataclass
+class _ResolvedModel:
+    """Internal helper describing a resolved model entry."""
+
+    info: ModelSchema
+    path: Path
+
+
+class ModelDownloader:
+    """Download and cache model files declared in the registry."""
+
+    def __init__(self, model_dir: Path | None = None) -> None:
+        cfg = load_config()
+        self.model_dir = Path(model_dir or cfg.model_dir)
+        self.model_dir.mkdir(parents=True, exist_ok=True)
+        self._registry: Dict[str, _ResolvedModel] | None = None
+
+    # ------------------------------------------------------------------
+    # Registry helpers
+    # ------------------------------------------------------------------
+    def get_registry(self) -> Dict[str, ModelSchema]:
+        """Return the model registry mapping names to schemas."""
+
+        if self._registry is None:
+            data = load_effective_registry()
+            resolved: Dict[str, _ResolvedModel] = {}
+            for raw in data.get("models", []):
+                try:
+                    info = ModelSchema.model_validate(raw)
+                except Exception:
+                    # Skip invalid entries – they will be reported by validation
+                    # utilities, but the downloader keeps working with the valid
+                    # ones it has.
+                    continue
+                filename = info.filename or Path(info.resolved_urls()[0]).name
+                resolved[info.name] = _ResolvedModel(info=info, path=self.model_dir / filename)
+            self._registry = resolved
+
+        # ``self._registry`` maps to ``_ResolvedModel`` but the public contract is
+        # a mapping to ``ModelSchema``.  Expose only the ``info`` attribute to the
+        # outside world.
+        return {name: rm.info for name, rm in self._registry.items()}
+
+    # ------------------------------------------------------------------
+    # Model management
+    # ------------------------------------------------------------------
+    def _entry(self, name: str) -> _ResolvedModel:
+        """Return the resolved registry entry for ``name``."""
+
+        if self._registry is None:
+            # Populate the cache
+            self.get_registry()
+        assert self._registry is not None  # for type-checkers
+        return self._registry[name]
+
+    def is_model_downloaded(self, name: str) -> bool:
+        """Return ``True`` if the model file exists and matches the checksum."""
+
+        entry = self._entry(name)
+        if not entry.path.exists():
+            return False
+        return self._sha256(entry.path) == entry.info.sha256
+
+    def download_model(self, name: str) -> Path:
+        """Download ``name`` to the configured model directory.
+
+        The downloaded file is verified against the SHA256 checksum declared in
+        the registry.  A :class:`RuntimeError` is raised if the checksum does not
+        match.
+        """
+
+        entry = self._entry(name)
+        url = entry.info.resolved_urls()[0]
+        self._download(url, entry.path)
+        if self._sha256(entry.path) != entry.info.sha256:
+            entry.path.unlink(missing_ok=True)
+            raise RuntimeError("Model checksum verification failed")
+        return entry.path
+
+    # ------------------------------------------------------------------
+    # Static utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _sha256(path: Path) -> str:
+        hash_obj = hashlib.sha256()
+        with open(path, "rb") as fh:  # pragma: no cover - small helper
+            for chunk in iter(lambda: fh.read(8192), b""):
+                hash_obj.update(chunk)
+        return hash_obj.hexdigest()
+
+    @staticmethod
+    def _download(url: str, dest: Path) -> None:  # pragma: no cover - network
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_suffix(".tmp")
+        with urllib.request.urlopen(url) as resp, open(tmp, "wb") as fh:
+            fh.write(resp.read())
+        tmp.replace(dest)
+

--- a/tests/test_model_install_cli.py
+++ b/tests/test_model_install_cli.py
@@ -1,0 +1,62 @@
+"""Tests for the `model install` CLI command."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+from types import SimpleNamespace
+
+from scaleforge.cli.main import cli
+from scaleforge.models import downloader as downloader_mod
+from scaleforge.models.downloader import ModelDownloader
+
+
+def test_model_install_unknown(tmp_path, monkeypatch):
+    """Unknown models should result in a usage error listing available ones."""
+
+    monkeypatch.setattr(downloader_mod, "load_config", lambda: SimpleNamespace(model_dir=tmp_path))
+    monkeypatch.setattr(ModelDownloader, "get_registry", lambda self: {"foo": {}})
+    r = CliRunner().invoke(cli, ["model", "install", "bar"])
+    assert r.exit_code == 2
+    assert "Unknown model: bar" in r.output
+    assert "foo" in r.output
+
+
+def test_model_install_already_downloaded(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader_mod, "load_config", lambda: SimpleNamespace(model_dir=tmp_path))
+    monkeypatch.setattr(ModelDownloader, "get_registry", lambda self: {"foo": {}})
+    monkeypatch.setattr(ModelDownloader, "is_model_downloaded", lambda self, name: True)
+    r = CliRunner().invoke(cli, ["model", "install", "foo"])
+    assert r.exit_code == 0
+    assert "already downloaded" in r.output
+
+
+def test_model_install_success(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader_mod, "load_config", lambda: SimpleNamespace(model_dir=tmp_path))
+    monkeypatch.setattr(ModelDownloader, "get_registry", lambda self: {"foo": {}})
+    monkeypatch.setattr(ModelDownloader, "is_model_downloaded", lambda self, name: False)
+    called = {}
+
+    def fake_download(self, name):
+        called["name"] = name
+
+    monkeypatch.setattr(ModelDownloader, "download_model", fake_download)
+    r = CliRunner().invoke(cli, ["model", "install", "foo"])
+    assert r.exit_code == 0
+    assert "Installing model: foo" in r.output
+    assert "✅ Done." in r.output
+    assert called.get("name") == "foo"
+
+
+def test_model_install_download_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader_mod, "load_config", lambda: SimpleNamespace(model_dir=tmp_path))
+    monkeypatch.setattr(ModelDownloader, "get_registry", lambda self: {"foo": {}})
+    monkeypatch.setattr(ModelDownloader, "is_model_downloaded", lambda self, name: False)
+
+    def boom(self, name):
+        raise RuntimeError("network fail")
+
+    monkeypatch.setattr(ModelDownloader, "download_model", boom)
+    r = CliRunner().invoke(cli, ["model", "install", "foo"])
+    assert r.exit_code == 1
+    assert "network fail" in r.output
+


### PR DESCRIPTION
## Summary
- add `ModelDownloader` for registry lookup, verification and downloads
- hook `model install` CLI command to downloader with error handling
- test model installation scenarios and failure paths

## Testing
- `PYTHONPATH=src pytest -vv --disable-warnings`
- `PYTHONPATH=src pytest tests/test_model_install_cli.py -k "" -vv --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a55cacc51c832ba9cd4c41eafd884f