### PR TITLE
Expose CLI config loader and stub pipeline

### DIFF
--- a/src/scaleforge/backend/torch_backend.py
+++ b/src/scaleforge/backend/torch_backend.py
@@ -156,6 +156,11 @@ class TorchRealESRGANBackend(Backend):
         job: "Job" | None = None,
     ) -> None:
         """Upscale ``src`` to ``dst`` using the configured model."""
+        if self.stub:
+            logger.info("Stub mode: copying %s -> %s", src, dst)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            Image.open(src).save(dst)
+            return
 
         if job and job.metadata and "scale" in job.metadata:
             scale = int(job.metadata["scale"])

--- a/src/scaleforge/pipeline/entry.py
+++ b/src/scaleforge/pipeline/entry.py
@@ -7,7 +7,8 @@ import shutil
 from pathlib import Path
 from typing import Sequence
 
-from scaleforge.backend.base import Backend, TorchBackend
+from scaleforge.backend.base import Backend
+from scaleforge.backend.torch_backend import TorchBackend
 from scaleforge.db.models import Job, JobStatus, get_conn
 from .queue import JobQueue
 
@@ -49,8 +50,8 @@ def run_pipeline(
 
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
 
-    # Use the simple TorchBackend stub for now; heavy backends can hook in later
-    backend: Backend = TorchBackend()
+    # Use the Torch backend in stub mode for now; heavy deps hook in later
+    backend: Backend = TorchBackend(stub=True)
 
     db_path = output_dir / "pipeline.db"
     queue = JobQueue(db_path, backend)


### PR DESCRIPTION
## Summary
- expose `load_config` in CLI for monkeypatching and lazy loading
- run pipeline with stub Torch backend and fix imports
- allow Torch backend to copy images in stub mode

## Testing
- `PYTHONPATH=src python -m scaleforge.cli --help`
- `PYTHONPATH=src pytest tests/test_cli_smoke.py -k '' -q`
- `PYTHONPATH=src SF_HEAVY_TESTS=1 pytest tests/test_torch_backend.py -k '' -q`


------
https://chatgpt.com/codex/tasks/task_e_68a552d4cf34832b8ee182a5b0b97bad