### PR TITLE
Remove stub packages from demo extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,7 @@ torch = [
     "xformers>=0.0.22; sys_platform != 'win32'",
     "charset-normalizer<3.0.0; python_version >= '3.12'"
 ]
-demo = [
-    "torch-stub>=0.1",
-    "realesrgan-stub>=0.1",
-]
+demo = []
 
 # Development extras (includes test/lint)
 dev = [


### PR DESCRIPTION
## Summary
- drop `torch-stub` and `realesrgan-stub` from the `demo` optional dependency list
- rely on test monkeypatching instead of stub packages

## Testing
- `python -m pip install -e ".[demo]"`
- `pytest -q -k "demo or cli_help"`


------
https://chatgpt.com/codex/tasks/task_e_68a583f6bad0832bae3fc4bcfc5bfec0