### PR TITLE
Add watchdog dependency for GUI extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ pip install -U pip
 pip install -e ".[demo]" pytest
 ````
 
+### GUI
+
+To use the graphical interface, install the optional GUI dependencies:
+
+```bash
+pip install -e ".[gui]"
+```
+
+This pulls in Kivy and Watchdog for desktop UI and file-system monitoring.
+
 ---
 
 ## GPU Detection & Capability Cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ scaleforge = "scaleforge.cli.main:cli"
 
 [project.optional-dependencies]
 gui = [
-    "kivy>=2.3.0"
+    "kivy>=2.3.0",
+    "watchdog>=4.0.0"
 ]
 # Runtime heavy extras
 torch = [


### PR DESCRIPTION
## Summary
- include `watchdog>=4.0.0` in GUI optional dependencies
- document GUI installation instructions and mention Watchdog

## Testing
- `pip install .[gui]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58c4a82f8832b9cf7a8e0a3f01029