### PR TITLE
feat: add CLI info command

### DIFF
--- a/src/scaleforge/cli/__init__.py
+++ b/src/scaleforge/cli/__init__.py
@@ -1,2 +1,4 @@
 from .main import cli
+from . import info as _info  # noqa: F401 ensure subcommands are registered
 
+__all__ = ["cli"]

--- a/src/scaleforge/cli/info.py
+++ b/src/scaleforge/cli/info.py
@@ -1,11 +1,33 @@
 
 
 from __future__ import annotations
-import click
-from typing import Optional
 
-@click.command("info")
-def info():
+import platform
+
+import click
+
+from scaleforge.backend.detector import detect_backend
+from .main import _CFG, cli, load_config
+
+
+@cli.command("info")
+def info() -> None:
     """Show system and configuration information."""
-    click.echo("System information placeholder")
+    cfg = _CFG
+    if cfg is None:
+        loader = load_config
+        if loader is None:  # pragma: no cover - should be loaded by ``cli``
+            from scaleforge.config.loader import load_config as _load_config
+
+            loader = _load_config
+        cfg = loader()
+
+    click.echo(f"Detected backend: {detect_backend()}")
+    if cfg is not None:
+        click.echo(f"Database path: {cfg.database_path}")
+        click.echo(f"Log dir: {cfg.log_dir}")
+        click.echo(f"Model dir: {cfg.model_dir}")
+
+    click.echo(f"Python: {platform.python_version()}")
+    click.echo(f"OS: {platform.platform()}")
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,5 +1,6 @@
 from click.testing import CliRunner
-from scaleforge.cli.main import cli
+from scaleforge.cli import cli
+from scaleforge.backend.detector import detect_backend
 
 def test_cli_help_command():
     r = CliRunner().invoke(cli, ["--help"])
@@ -11,6 +12,13 @@ def test_cli_detect_backend_debug():
     assert r.exit_code >= 0  # Just verify it didn't crash
     if r.exit_code == 0:
         assert "torch-cpu" in r.output
+
+
+def test_cli_help_info_command():
+    backend = detect_backend()
+    r = CliRunner().invoke(cli, ["info"])
+    assert r.exit_code == 0
+    assert backend in r.output
 
 from PIL import Image
 from scaleforge.config.loader import AppConfig


### PR DESCRIPTION
## Summary
- add `info` CLI subcommand showing backend, config paths, and environment details
- register `info` command for `python -m scaleforge.cli`
- add smoke test for the new command

## Testing
- `python -m scaleforge.cli info`
- `pytest tests/test_cli_smoke.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a590167a1c832bbfcee9919559cfbd