### PR TITLE
Resize demo images using scale factor

### DIFF
--- a/src/scaleforge/demo/upscale.py
+++ b/src/scaleforge/demo/upscale.py
@@ -21,7 +21,16 @@ def upscale_image(
     """
 
     try:
-        Image.open(input_path).save(output_path)
+        im = Image.open(input_path)
+        new_size = (int(im.width * scale), int(im.height * scale))
+        resample_map = {
+            "nearest": Image.NEAREST,
+            "bilinear": Image.BILINEAR,
+            "bicubic": Image.BICUBIC,
+            "lanczos": Image.LANCZOS,
+        }
+        resample = resample_map.get(mode.lower(), Image.LANCZOS)
+        im.resize(new_size, resample=resample).save(output_path)
     except Exception as e:
         if debug:
             print(f"Error processing {input_path}: {e}")

--- a/tests/test_demo_batch_extras.py
+++ b/tests/test_demo_batch_extras.py
@@ -27,6 +27,8 @@ def test_overwrite_flag(tmp_path: Path):
     r1 = CliRunner().invoke(cli, ["demo-batch","-i",str(src),"-o",str(dst),"-s","2","--mode","nearest","--suffix","@2x"])
     assert r1.exit_code == 0
     out = next(dst.rglob("*.png"))
+    with Image.open(out) as im:
+        assert im.size == (20,14)
     first_mtime = out.stat().st_mtime
     # Change input and run without overwrite -> should skip
     time.sleep(0.1)
@@ -42,4 +44,6 @@ def test_overwrite_flag(tmp_path: Path):
     r3 = CliRunner().invoke(cli, ["demo-batch","-i",str(src),"-o",str(dst),"-s","2","--mode","nearest","--suffix","@2x","--overwrite"])
     assert r3.exit_code == 0
     assert "wrote:" in r3.output
+    with Image.open(out) as im:
+        assert im.size == (20,14)
     assert out.stat().st_mtime > first_mtime

--- a/tests/test_demo_batch_filters.py
+++ b/tests/test_demo_batch_filters.py
@@ -38,6 +38,8 @@ def test_include_exclude_and_limit(tmp_path: Path):
     # Names should have suffix
     for p in outs:
         assert "@2x" in p.stem
+        with Image.open(p) as im:
+            assert im.size == (16,12)
 
 def test_dry_run_with_filters(tmp_path: Path):
     src = tmp_path / "in"; dst = tmp_path / "out"; src.mkdir()


### PR DESCRIPTION
## Summary
- scale images in `upscale_image` using Pillow resize and resampling filter
- test CLI batch processing ensures output dimensions change

## Testing
- `pytest tests/test_demo_batch_extras.py tests/test_demo_batch_filters.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5901640a8832baa64e05181354671